### PR TITLE
Fix error when deleting anime

### DIFF
--- a/src/api/malApi.ts
+++ b/src/api/malApi.ts
@@ -29,7 +29,10 @@ export const updateAnime = async (entry: Media) => {
 };
 
 export const deleteAnime = async (entry: Media) => {
-	await sendRequest(`/anime/${entry.id}/my_list_status`, "DELETE");
+	await sendRequest(
+		`https://api.myanimelist.net/v2/anime/${entry.id}/my_list_status`,
+		"DELETE"
+	);
 };
 
 export const updateManga = async (entry: Media) => {


### PR DESCRIPTION
This should fix an error that occurs when syncing:
```
~  malsync --sync
Sync: checking for leftover changes
Sync: updating anime
...
Sync: deleting anime
TypeError: Only absolute URLs are supported
```